### PR TITLE
feat: Added color variable support to parse from YAML

### DIFF
--- a/lib/interpreter/color_pass.dart
+++ b/lib/interpreter/color_pass.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:yaml/yaml.dart';
+
+/// Parses the [input] and returns a mapping from variable to [Color]
+Map<String, Color> parseColorVariables(YamlMap input) {
+  final variableToColorMapping = <String, Color>{};
+  if (input.containsKey('color')) {
+    final colorSection = input['color'] as YamlList;
+    for (final (colorYaml as YamlMap) in colorSection) {
+      Color? color;
+      if (colorYaml.containsKey('hex')) {
+        final colorHex = (colorYaml['hex'] as String).trim();
+        color = Color(int.parse('0xff$colorHex'));
+      } else if (colorYaml.containsKey('red') &&
+          colorYaml.containsKey('green') &&
+          colorYaml.containsKey('blue')) {
+        final red = int.parse(
+          (colorYaml['red'] as String).replaceFirst('%', '').trim(),
+        );
+        final green = int.parse(
+          (colorYaml['green'] as String).replaceFirst('%', '').trim(),
+        );
+        final blue = int.parse(
+          (colorYaml['blue'] as String).replaceFirst('%', '').trim(),
+        );
+
+        color = Color.fromRGBO(
+          (red / 100 * 255).round(),
+          (green / 100 * 255).round(),
+          (blue / 100 * 255).round(),
+          1,
+        );
+      } else if (colorYaml.containsKey('red_int') &&
+          colorYaml.containsKey('green_int') &&
+          colorYaml.containsKey('blue_int')) {
+        final red = colorYaml['red_int'] as int;
+        final green = colorYaml['green_int'] as int;
+        final blue = colorYaml['blue_int'] as int;
+
+        color = Color.fromRGBO(red, green, blue, 1);
+      }
+      if (color != null && colorYaml.containsKey('id')) {
+        final idString = (colorYaml['id'] as String).trim();
+        variableToColorMapping['id($idString)'] = color;
+      }
+    }
+  }
+
+  return variableToColorMapping;
+}

--- a/lib/interpreter/yaml_parser_pass.dart
+++ b/lib/interpreter/yaml_parser_pass.dart
@@ -1,3 +1,4 @@
+import 'package:esphome_display_editor/interpreter/color_pass.dart';
 import 'package:esphome_display_editor/interpreter/display_object_pass.dart';
 import 'package:esphome_display_editor/interpreter/display_parser_pass.dart';
 import 'package:esphome_display_editor/interpreter/font_pass.dart';
@@ -18,8 +19,8 @@ List<DisplayObject> parseDisplayObjects(
   if (yaml != null && verifyDisplayComponent(yaml)) {
     final codeLines = extractCode(yaml);
 
-    // Extract potential fonts from the yaml
     final variableToTextStyleMapping = parseFontVariables(yaml);
+    final variableToColorMapping = parseColorVariables(yaml);
 
     // Extract variables from code
     final (variableToObjectMapping, passedCodeLines) =
@@ -29,6 +30,7 @@ List<DisplayObject> parseDisplayObjects(
       {
         ...variableToObjectMapping,
         ...variableToTextStyleMapping,
+        ...variableToColorMapping,
         ...configurableVariables,
       },
     ).parseDisplayCode(passedCodeLines);

--- a/test/interpreter/color_pass_test.dart
+++ b/test/interpreter/color_pass_test.dart
@@ -1,0 +1,74 @@
+import 'package:esphome_display_editor/interpreter/color_pass.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  group('Testing parseColorVariablse method', () {
+    test('Check with hex color', () {
+      // Arrange
+      const name = 'test_id';
+      const variableName = 'id($name)';
+      const expected = 0xffff3340;
+      final input = loadYaml('''
+                color:
+                  - id: $name
+                    hex: ff3340
+            ''') as YamlMap;
+
+      // Act
+      final result = parseColorVariables(input);
+
+      // Assert
+      expect(result.containsKey(variableName), true);
+      expect(
+        result[variableName]!.value.toRadixString(16),
+        expected.toRadixString(16),
+      );
+    });
+    test('Check with percentage colors', () {
+      // Arrange
+      const name = 'test_id';
+      const variableName = 'id($name)';
+      const expected = 0xffff0000;
+      final input = loadYaml('''
+                color:
+                  - id: $name
+                    red: 100%
+                    green: 0%
+                    blue: 0%
+            ''') as YamlMap;
+      // Act
+      final result = parseColorVariables(input);
+
+      // Assert
+      expect(result.containsKey(variableName), true);
+      expect(
+        result[variableName]!.value.toRadixString(16),
+        expected.toRadixString(16),
+      );
+    });
+    test('Check with colors', () {
+      // Arrange
+      const name = 'test_id';
+      const variableName = 'id($name)';
+      const expectedRed = 200;
+      const expectedGreen = 144;
+      const expectedBlue = 12;
+      final input = loadYaml('''
+                color:
+                  - id: $name
+                    red_int: $expectedRed
+                    green_int: $expectedGreen
+                    blue_int: $expectedBlue
+            ''') as YamlMap;
+      // Act
+      final result = parseColorVariables(input);
+
+      // Assert
+      expect(result.containsKey(variableName), true);
+      expect(result[variableName]!.red, expectedRed);
+      expect(result[variableName]!.green, expectedGreen);
+      expect(result[variableName]!.blue, expectedBlue);
+    });
+  });
+}


### PR DESCRIPTION
Implemented the parsing support for the color YAML field, can parse the given implementations as described in the
[docs](https://esphome.io/components/display/index.html#color).

Right now the white value is dropped from the color, because this seems to be part of RGBW spec for LED lights, not necessarily for displays. Might have to change this later if this is actually used as opacity/alpha value.

Closes #1 